### PR TITLE
feat: add configurable bypass paths for ACME certificate renewal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Configurable `bypassPaths` in WasmPlugin CRD to allow specific paths to skip JWT validation [#1](https://github.com/Klazomenai/istio-jwt-wasm/issues/1)
+- Default bypass for `/.well-known/acme-challenge/` paths to support ACME certificate renewal
+- Path-based exemption logging with emoji indicators for visibility
+
 ### Known Issues
 - No circuit breaker pattern for authorization service failures
 - No fallback or retry logic for failed authorization calls

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ The plugin is configured via the `pluginConfig` section of the Istio WasmPlugin 
 |-------|---------|-------------|
 | `authorizeUrl` | `/authorize` | Authorization endpoint path |
 | `timeout` | `2000` | HTTP call timeout in milliseconds |
+| `bypassPaths` | `["/.well-known/acme-challenge/"]` | Array of path prefixes that bypass JWT validation |
 
 ### Cluster Name Format
 
@@ -154,6 +155,19 @@ pluginConfig:
   authorizeUrl: "/authorize"
   timeout: 3000
 ```
+
+#### ACME Certificate Renewal (Bypass Paths)
+
+```yaml
+pluginConfig:
+  cluster: "outbound|8080||jwt-auth-service.default.svc.cluster.local"
+  bypassPaths:
+    - "/.well-known/acme-challenge/"  # Allow ACME HTTP-01 challenges
+    - "/health"                        # Allow health checks
+    - "/metrics"                       # Allow metrics scraping
+```
+
+**Note**: Paths in `bypassPaths` will skip JWT validation entirely. Use with caution and only for paths that should be publicly accessible.
 
 ## How It Works
 


### PR DESCRIPTION
## Summary

Adds configurable `bypassPaths` support to allow specific request paths to skip JWT validation. This is required to support ACME HTTP-01 certificate challenges when using production Let's Encrypt certificates with JWT-protected endpoints.

## Changes

### Code Changes
- Added `BypassPaths []string` field to `pluginConfig` struct
- Implemented path prefix checking in `OnHttpRequestHeaders()` before JWT validation
- Default bypass path: `/.well-known/acme-challenge/` for ACME HTTP-01 challenges
- Returns `ActionContinue` for matching bypass paths (skips JWT authorization)
- Added logging with emoji indicators for visibility

### Documentation
- Updated README.md with `bypassPaths` configuration examples
- Updated CHANGELOG.md [Unreleased] section with new feature
- Added configuration table entry for optional `bypassPaths` field
- Included ACME certificate renewal example configuration

## Testing

- Built WASM module successfully (~3.1MB)
- Alpha image generated: `istio-jwt-wasm-feat-acme-bypass-paths-c8e732b`
- Deployed to devnet api-y with production Let's Encrypt certificates
- Verified ACME challenge path bypasses JWT (returns 404, not 401)
- Verified RPC/WS endpoints still require JWT (returns 401 without token)
- Production certificate reissued successfully (Issuer: Let's Encrypt R12)

## Configuration Example

```yaml
pluginConfig:
  cluster: "outbound|8080||jwt-auth-service.default.svc.cluster.local"
  bypassPaths:
    - "/.well-known/acme-challenge/"  # Allow ACME HTTP-01 challenges
    - "/health"                        # Allow health checks
    - "/metrics"                       # Allow metrics scraping
```

## Breaking Changes

None. The `bypassPaths` field is optional with sensible defaults.

## Related Issues

Closes #1